### PR TITLE
Prevent errors when 'config' is a directory, fixes #2

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,19 +18,16 @@ exports.get = function() {
 }
 
 function readFrom(configPath, cb) {
-  fs.exists(configPath, function(exists) {
-    if (exists) {
-      fs.readFile(configPath, 'utf8', function(err, data) {
-        if (err) throw err;
-        var parsedConfig = ini.parse(data);
-        mergeConfigs(config, parsedConfig);
-        cb();
-      });
-    } else {
+  fs.readFile(configPath, 'utf8', function(err, data) {
+    if (err) {
       // TODO: log it, but not to stdout/stderr - git doesn't do that
       // console.log('"' + configPath + '" not found');
-      cb();
     }
+    else {
+      var parsedConfig = ini.parse(data);
+      mergeConfigs(config, parsedConfig);
+    }
+    cb();
   });
 }
 


### PR DESCRIPTION
fs.exists should not be used according to node.js docs, so I removed it and ignore errors like in the original code.
